### PR TITLE
fix: rm WeakMap, we can't use it for key with type string

### DIFF
--- a/source/state.ts
+++ b/source/state.ts
@@ -194,7 +194,7 @@ export abstract class State {
         () => Array.prototype.slice.call(object, 0)
       );
     }
-    else if (object instanceof WeakMap || object instanceof Map) {
+    else if (object instanceof Map) {
       return metaOperations(
         // Update map key
         (parent, key: number | string, value: K) => {
@@ -217,9 +217,7 @@ export abstract class State {
         },
 
         // Clone
-        () => object instanceof WeakMap
-          ? new WeakMap<string, any>(<any> object)
-          : new Map<string, any>(<any> object)
+        () => new Map<string, any>(<any> object)
       );
     }
     else if (object instanceof WeakSet || object instanceof Set) {


### PR DESCRIPTION
Hey, I would like to fix issue #14 
We can't use WeakMap for keys with type string.
See this: https://github.com/tunnelvisionlabs/antlr4ts/issues/285#issuecomment-284272412