### PR TITLE
fix: allow typescript unused checks

### DIFF
--- a/source/compose-reducers.ts
+++ b/source/compose-reducers.ts
@@ -1,8 +1,5 @@
 import {Reducer, Action} from 'redux';
 
-import {Iterable} from 'immutable';
-
-import {FormException} from './form-exception';
 import {State} from './state';
 
 export const composeReducers =

--- a/source/configure.ts
+++ b/source/configure.ts
@@ -1,5 +1,3 @@
-import {FormControl} from '@angular/forms';
-
 import {
   Action,
   Store,

--- a/source/connect-array.ts
+++ b/source/connect-array.ts
@@ -15,7 +15,6 @@ import {
 import {
   NG_VALUE_ACCESSOR,
   AbstractControl,
-  DefaultValueAccessor,
   FormArray,
   FormArrayName,
   FormControl,
@@ -36,8 +35,6 @@ import {
   NG_VALIDATORS
 } from '@angular/forms';
 import {Unsubscribe} from 'redux';
-
-import {Subscription} from 'rxjs';
 
 import {ConnectBase} from './connect-base';
 import {FormStore} from './form-store';
@@ -61,8 +58,6 @@ export class ConnectArrayTemplate {
 })
 export class ConnectArray extends ControlContainer implements OnInit {
   private stateSubscription: Unsubscribe;
-
-  private formSubscription: Subscription;
 
   private array = new FormArray([]);
 
@@ -180,8 +175,8 @@ export class ConnectArray extends ControlContainer implements OnInit {
   }
 
   private registerInternals(array) {
-    array.registerControl = c => {};
-    array.registerOnChange = fn => {};
+    array.registerControl = () => {};
+    array.registerOnChange = () => {};
 
     Object.defineProperties(this, {
       _rawValidators: {
@@ -251,7 +246,7 @@ export class ConnectArray extends ControlContainer implements OnInit {
       return array;
     }
 
-    const associate = <T>(value): FormGroup => {
+    const associate = (value): FormGroup => {
       const group = new FormGroup({});
       group.setParent(parent);
 
@@ -286,8 +281,8 @@ export class ConnectArray extends ControlContainer implements OnInit {
   private simpleAccessor() {
     return {
       writeValue: value => this.control.setValue(value),
-      registerOnChange(fn) {},
-      registerOnTouched(fn) {}
+      registerOnChange() {},
+      registerOnTouched() {}
     };
   }
 }

--- a/source/connect-base.ts
+++ b/source/connect-base.ts
@@ -1,14 +1,10 @@
-import {
-  Directive,
-  Input,
-} from '@angular/core';
+import { Input } from '@angular/core';
 
 import {
   AbstractControl,
   FormControl,
   FormGroup,
   FormArray,
-  NgForm,
   NgControl,
 } from '@angular/forms';
 
@@ -18,7 +14,6 @@ import { Unsubscribe } from 'redux';
 
 import 'rxjs/add/operator/debounceTime';
 
-import { FormException } from './form-exception';
 import { FormStore } from './form-store';
 import { State } from './state';
 
@@ -66,13 +61,11 @@ export class ConnectBase {
     }
   }
 
-  private ngAfterContentInit() {
+  ngAfterContentInit() {
     Promise.resolve().then(() => {
       this.resetState();
 
-      this.stateSubscription = this.store.subscribe(state => {
-        this.resetState();
-      });
+      this.stateSubscription = this.store.subscribe(() => this.resetState());
 
       Promise.resolve().then(() => {
         this.formSubscription = (<any>this.form.valueChanges).debounceTime(0).subscribe(values => this.publish(values));

--- a/source/connect-reactive.ts
+++ b/source/connect-reactive.ts
@@ -3,10 +3,6 @@ import {
   Input,
 } from '@angular/core';
 
-import {
-  NgForm
-} from '@angular/forms';
-
 import {FormStore} from './form-store';
 
 import {ConnectBase} from './connect-base';

--- a/source/connect.ts
+++ b/source/connect.ts
@@ -1,15 +1,8 @@
-import {
-  Directive,
-  Input,
-} from '@angular/core';
+import { Directive } from '@angular/core';
 
-import {
-  NgForm
-} from '@angular/forms';
-
+import { NgForm } from '@angular/forms';
 
 import {FormStore} from './form-store';
-import {State} from './state';
 import {ConnectBase} from './connect-base';
 
 

--- a/source/form-reducer.ts
+++ b/source/form-reducer.ts
@@ -1,17 +1,8 @@
-import {
-  Iterable,
-  Map,
-  fromJS
-} from 'immutable';
+import {Iterable} from 'immutable';
 
-import {Action, Reducer} from 'redux';
+import {Action} from 'redux';
 
-import {FormException} from './form-exception';
-
-import {
-  FORM_CHANGED,
-  FormStore,
-} from './form-store';
+import {FORM_CHANGED} from './form-store';
 
 import {State} from './state';
 

--- a/source/form-store.ts
+++ b/source/form-store.ts
@@ -4,7 +4,7 @@ import {NgForm} from '@angular/forms';
 
 import {NgRedux} from '@angular-redux/store';
 
-import {Action, Store, Unsubscribe} from 'redux';
+import {Action, Unsubscribe} from 'redux';
 
 export interface AbstractStore<RootState> {
   /// Dispatch an action

--- a/source/state.ts
+++ b/source/state.ts
@@ -65,14 +65,6 @@ export abstract class State {
   }
 
   static assign<State>(state: State, path: string[], value?) {
-    interface Modifiable {
-      key: string;
-      operations: {
-        clone<T>(): T;
-        update<T, V>(key: number | string, value: V): T;
-      };
-    };
-
     const operations = State.inspect(state);
 
     if (path.length === 0) {
@@ -157,7 +149,7 @@ export abstract class State {
           }
         },
         // Merge
-        (parent, key: number | string | string[], value: K, setter: (v: K) => K) => {
+        (parent, key: number | string | string[], value: K) => {
           if (key) {
             return parent.mergeDeepIn(Array.isArray(key) ? key : [key], value);
           }
@@ -185,7 +177,7 @@ export abstract class State {
         },
 
         // Merge
-        (parent, key: number | string, value: K, setter: (v: K) => K) => {
+        (parent, _, value: K, setter: (v: K) => K) => {
           setter(parent.concat(value));
           return parent;
         },
@@ -210,7 +202,7 @@ export abstract class State {
         },
 
         // Merge
-        (parent: Map<string, any>, key: number | string, value: K, setter: (v: K) => K) => {
+        (parent: Map<string, any>, _, value: K) => {
           const m = new Map<string, any>(<any> value);
           m.forEach((value, key) => parent.set(key, value));
           return parent;
@@ -238,7 +230,7 @@ export abstract class State {
         },
 
         // Merge
-        (parent: Set<any>, key: number | string, value, setter: (v: K) => K) => {
+        (parent: Set<any>, _, value) => {
           for (const element of value) {
             parent.add(element);
           }
@@ -274,7 +266,7 @@ export abstract class State {
                }
                 return Object.assign(parent, value);
              },
-             (parent, key: number | string, value: K, setter: (v: K) => K) => {
+             (parent, _, value: K) => {
                for (const k of Object.keys(value)) {
                  parent[k] = value[k];
                }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,9 @@
     "inlineSourceMap": true,
     "declaration": true,
     "outDir": "dist",
-    "rootDir": ""
+    "rootDir": "",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "awesomeTypescriptLoaderOptions": {
     "emitRequireType": false,


### PR DESCRIPTION
The library currently does not work in projects that have noUnusedLocals and noUnusedParameters set inside of tsconfig.json. This should bring the project into compliance with those rules.