### PR TITLE
fix: external tslint running on library source code

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,0 @@
-///<reference path="./source/index.ts" />
-
-declare module "@angular-redux/form" {
-  export * from 'source/index';
-}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "prepublish": "npm run build"
   },
   "main": "dist/source/index.js",
-  "typings": "source/index",
   "repository": "https://github.com/angular-redux/form",
   "license": "MIT"
 }


### PR DESCRIPTION
Because of unneeded references to the source folder through the type definitions, tslint when run on a library consuming project will try and lint the source code of this library. This fixes that issue.