### PR TITLE
fix: reactive forms not updating on changes in store

### DIFF
--- a/source/connect/connect-base.ts
+++ b/source/connect/connect-base.ts
@@ -97,7 +97,10 @@ export class ConnectBase {
       throw new Error(`Unknown type of form element: ${formElement.constructor.name}`);
     }
 
-    return pairs.filter(p => (<any>p.control)._parent === this.form.control);
+    return pairs.filter(p => {
+        const parent = (p.control as any)._parent;
+        return parent === this.form.control || parent === this.form;
+    });
   }
 
   private resetState() {
@@ -114,12 +117,10 @@ export class ConnectBase {
     children.forEach(c => {
       const { path, control } = c;
 
-      const value = State.get(this.getState(), this.path.concat(c.path));
+      const value = State.get(this.getState(), this.path.concat(path));
 
       if (control.value !== value) {
-        const phonyControl = <any>{ path: path };
-
-        this.form.updateModel(phonyControl, value);
+        control.setValue(value);
       }
     });
   }


### PR DESCRIPTION
Fixes reactive forms not updating on changes in store data. Writing changes to the store works.
They don't have a parent `NgForm`, so the update never gets triggered.

Additionally `NgForm.updateModel` can not be called since it is no `NgForm`.
Now using the `FormControl.setValue` function uniformly instead.