### PR TITLE
Fix reactive forms, debounce inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ logs
 **/npm-debug.log*
 
 .idea
+.settings
 
 # Runtime data
 pids
@@ -50,3 +51,5 @@ source/*ngfactory.ts
 source/*ngsummary.json
 
 *.tgz
+/.project
+/.tern-project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.7.0 - Fix reactive forms, support custom debounce time for form inputs
+
+* https://github.com/angular-redux/form/pull/48
+
 # 6.5.1 - Support typescript unused checks
 
 * https://github.com/angular-redux/form/pull/32

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ Both `NgRedux<T>` and `Redux.Store<T>` conform to this shape. If you have a more
 complicated use-case that is not covered here, you could even create your own store
 shim as long as it conforms to the shape of `AbstractStore<RootState>`.
 
+#### Input debounce
+
+To debounce emitted FORM_CHANGED actions simply specify the desired debounce time in milliseconds on the form:
+
+```html
+<form connect="myForm" debounce="500">
+```
+
 ### How the bindings work
 
 The bindings work by inspecting the shape of your form and then binding to a Redux

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-redux/form",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "Build Angular 2+ forms with Redux",
   "dependencies": {
     "immutable": "^3.8.1"

--- a/source/connect/connect-base.ts
+++ b/source/connect/connect-base.ts
@@ -93,7 +93,13 @@ export class ConnectBase {
     }
     else if (formElement instanceof FormGroup) {
       for (const k of Object.keys(formElement.controls)) {
-        pairs.push({ path: path.concat([k]), control: formElement.controls[k] });
+        // If the control is a FormGroup or FormArray get the descendants of the the control instead of the control itself to always patch fields, not groups/arrays
+        if(formElement.controls[k] instanceof FormArray || formElement.controls[k] instanceof FormGroup) {
+          pairs.push(...this.descendants(path.concat([k]), formElement.controls[k]));
+        }
+        else {
+          pairs.push({ path: path.concat([k]), control: formElement.controls[k] });
+        }
       }
     }
     else if (formElement instanceof NgControl || formElement instanceof FormControl) {
@@ -103,7 +109,7 @@ export class ConnectBase {
       throw new Error(`Unknown type of form element: ${formElement.constructor.name}`);
     }
 
-    return pairs.filter(p => (<any>p.control)._parent === this.form.control || (<any>p.control)._parent === this.form);
+    return pairs;
   }
 
   private resetState(emitEvent: boolean = true) {

--- a/source/connect/connect-base.ts
+++ b/source/connect/connect-base.ts
@@ -127,7 +127,7 @@ export class ConnectBase {
       const newValueIsEmpty: boolean = 'undefined' === typeof value || null === value || ('string' === typeof value && '' === value);
       const oldValueIsEmpty: boolean = 'undefined' === typeof control.value || null === control.value || ('string' === typeof control.value && '' === control.value);
 
-      // setValue() should only be called upon "real changes", meaning "null" and "undefined" should be treated equal to "" (empty string)
+      // patchValue() should only be called upon "real changes", meaning "null" and "undefined" should be treated equal to "" (empty string)
       // newValueIsEmpty: true,  oldValueIsEmpty: true  => no change
       // newValueIsEmpty: true,  oldValueIsEmpty: false => change
       // newValueIsEmpty: false, oldValueIsEmpty: true  => change
@@ -135,7 +135,7 @@ export class ConnectBase {
       //                        control.value === value => no change
       //                        control.value !== value => change
       if (oldValueIsEmpty !== newValueIsEmpty || (!oldValueIsEmpty && !newValueIsEmpty && control.value !== value)) {
-        control.setValue(newValueIsEmpty ? '' : value, {emitEvent});
+        control.patchValue(newValueIsEmpty ? '' : value, {emitEvent});
       }
     });
   }

--- a/source/connect/connect-base.ts
+++ b/source/connect/connect-base.ts
@@ -17,8 +17,6 @@ import 'rxjs/add/operator/debounceTime';
 import { FormStore } from '../form-store';
 import { State } from '../state';
 
-import { Iterable } from 'immutable';
-
 export interface ControlPair {
   path: Array<string>;
   control: AbstractControl;

--- a/source/connect/connect-base.ts
+++ b/source/connect/connect-base.ts
@@ -107,6 +107,8 @@ export class ConnectBase {
   }
 
   private resetState(emitEvent: boolean = true) {
+    emitEvent = !!emitEvent ? true : false;
+    
     var formElement;
     
     if (this.form.control === undefined) {
@@ -133,7 +135,7 @@ export class ConnectBase {
       //                        control.value === value => no change
       //                        control.value !== value => change
       if (oldValueIsEmpty !== newValueIsEmpty || (!oldValueIsEmpty && !newValueIsEmpty && control.value !== value)) {
-        control.setValue(newValueIsEmpty ? '' : value, {emitEvent: !!emitEvent});
+        control.setValue(newValueIsEmpty ? '' : value, {emitEvent});
       }
     });
   }

--- a/source/connect/connect-base.ts
+++ b/source/connect/connect-base.ts
@@ -119,12 +119,12 @@ export class ConnectBase {
     children.forEach(c => {
       const { path, control } = c;
 
-      const value = State.get(this.getState(), this.path.concat(path));
+      const value                    = State.get(this.getState(), this.path.concat(path));
+      const newValueIsEmpty: boolean = 'undefined' === typeof value || null === value || ('string' === typeof value && '' === value);
+      const oldValueIsEmpty: boolean = 'undefined' === typeof control.value || null === control.value || ('string' === typeof control.value && '' === control.value);
 
-      if (control.value !== value) {
-        const phonyControl = <any>{ path: path };
-
-        control.setValue(value, {emitEvent});
+      if (oldValueIsEmpty !== newValueIsEmpty && control.value !== value) {
+        control.setValue(newValueIsEmpty ? '' : value, {emitEvent});
       }
     });
   }

--- a/source/connect/connect-base.ts
+++ b/source/connect/connect-base.ts
@@ -123,7 +123,7 @@ export class ConnectBase {
       const newValueIsEmpty: boolean = 'undefined' === typeof value || null === value || ('string' === typeof value && '' === value);
       const oldValueIsEmpty: boolean = 'undefined' === typeof control.value || null === control.value || ('string' === typeof control.value && '' === control.value);
 
-      if (oldValueIsEmpty !== newValueIsEmpty && control.value !== value) {
+      if (oldValueIsEmpty !== newValueIsEmpty || (!oldValueIsEmpty && !newValueIsEmpty && control.value !== value)) {
         control.setValue(newValueIsEmpty ? '' : value, {emitEvent});
       }
     });

--- a/source/state.ts
+++ b/source/state.ts
@@ -36,9 +36,13 @@ export abstract class State {
       else if (deepValue instanceof Map) {
         deepValue = (<Map<string, any>> <any> deepValue).get(k);
       }
-      else {
+      else if('object' === typeof deepValue && !Array.isArray(deepValue) && null !== deepValue) {
         deepValue = (deepValue as any)[k];
       }
+      else {
+        return undefined;
+      }
+      
 
       if (typeof fn === 'function') {
         const transformed = fn(parent, k, path.slice(path.indexOf(k) + 1), deepValue);


### PR DESCRIPTION
Fixes reative forms and adds custom debounce time for form inputs by adding `@Input('debounce')`
Works as expected with angular 5.1.0-beta.0 and immutable state.