### PR TITLE
feat: add peer dep support for Angular 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
   },
   "peerDependencies": {
     "@angular-redux/store": "^6.3.0",
-    "@angular/common": "^2.4.0 || ^4.0.0",
-    "@angular/compiler": "^2.4.0 || ^4.0.0",
-    "@angular/core": "^2.4.0 || ^4.0.0",
-    "@angular/forms": "^2.4.0 || ^4.0.0",
+    "@angular/common": "^2.4.0 || ^4.0.0 || ^5.0.0",
+    "@angular/compiler": "^2.4.0 || ^4.0.0 || ^5.0.0",
+    "@angular/core": "^2.4.0 || ^4.0.0 || ^5.0.0",
+    "@angular/forms": "^2.4.0 || ^4.0.0 || ^5.0.0",
     "redux": "^3.0"
   },
   "engines": {


### PR DESCRIPTION
The library seems to work just fine with Angular 5. This removes the npm peer dependency warning. v7 of this library will be built with Angular 5 and will not be backwards compatible.